### PR TITLE
chore: update test suite to supported versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,9 +11,6 @@ jobs:
                 php: [8.3, 8.2, 8.1]
                 laravel: [9.*, 10.*]
                 dependency-version: [prefer-lowest, prefer-stable]
-                include:
-                    - laravel: 8.*
-                      testbench: 6.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
@@ -36,7 +33,7 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                  composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
                   composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "illuminate/filesystem": "^10.38",
+        "illuminate/filesystem": "^10.38 || ^9.52",
         "league/flysystem-webdav": "^3.21"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.41",
-        "orchestra/testbench": "^8.18",
-        "phpunit/phpunit": "^10.1"
+        "orchestra/testbench": "^8.18 || ^v7.38",
+        "phpunit/phpunit": "^10.1 || ^9.6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": "^8.1",
         "illuminate/filesystem": "^10.38 || ^9.52",
-        "league/flysystem-webdav": "^3.21"
+        "league/flysystem-webdav": "^3.21",
+        "sabre/uri": ">=2.1.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.41",


### PR DESCRIPTION
Run tests with Laravel 10, 9 and PHP `8.3`, `8.2`, `8.1`.

Force `sabre/uri` to be `>=2.1.1` to avoid https://github.com/sabre-io/uri/issues/15 as it's required by `sabre/dav` at `^2.0`.